### PR TITLE
Fix SOAP state compatibility with flax.nnx

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,12 @@ version = "0.2.0"
 description = "SOAP Optimizer implemented in JAX"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-dependencies = ["jax", "jaxtyping", "optax"]
+dependencies = [
+    "chex>=0.1.90",
+    "jax",
+    "jaxtyping",
+    "optax",
+]
 
 [build-system]
 requires = ["uv_build>=0.8.5"]
@@ -25,4 +30,11 @@ quote-style = "double"
 indent-style = "space"
 
 [dependency-groups]
-dev = ["equinox>=0.13.2", "jax[cuda13]>0.6.0"]
+dev = [
+    "equinox>=0.13.2",
+    "flax>=0.10.7",
+    "ipython>=8.39.0",
+    "jax[cuda13]>0.6.0 ; sys_platform == 'linux'",
+    "pytest>=9.0.3",
+    "ty>=0.0.31",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,7 @@ version = "0.2.0"
 description = "SOAP Optimizer implemented in JAX"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-dependencies = [
-    "chex>=0.1.90",
-    "jax",
-    "jaxtyping",
-    "optax",
-]
+dependencies = ["chex", "jax", "jaxtyping", "optax"]
 
 [build-system]
 requires = ["uv_build>=0.8.5"]
@@ -36,5 +31,6 @@ dev = [
     "ipython>=8.39.0",
     "jax[cuda13]>0.6.0 ; sys_platform == 'linux'",
     "pytest>=9.0.3",
+    "ruff>=0.15.11",
     "ty>=0.0.31",
 ]

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -492,7 +492,7 @@ def _map_preconditioner(
 
 
 def _maybe_preconditioner_matrices(value: PreconditionerLike) -> Optional[Preconditioner]:
-    if isinstance(value, tuple) and len(value) > 0 and all(_is_preconditioner_matrix(m) for m in value):
+    if isinstance(value, tuple) and all(_is_preconditioner_matrix(m) for m in value):
         return value
 
     if not isinstance(value, Mapping):

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -1,5 +1,6 @@
+from collections.abc import Mapping
 from itertools import chain
-from typing import Callable, Iterable, NamedTuple, Optional, Union
+from typing import Callable, NamedTuple, Optional, Protocol, TypeAlias, Union, cast
 
 import chex
 import jax
@@ -11,27 +12,18 @@ from chex import Numeric
 from jaxtyping import Array
 from optax import GradientTransformation, Updates
 
-PreconditionerMatrix = Union[Array, None]
+
+class SupportsShapeDtype(Protocol):
+    shape: tuple[int, ...]
+    dtype: chex.ArrayDType
 
 
-@jtu.register_pytree_node_class
-class Preconditioner:
-    """Per-parameter preconditioner matrices (None for dimensions exceeding max_precond_dim)."""
-
-    __slots__ = ("matrices",)
-
-    def __init__(self, matrices: Iterable[PreconditionerMatrix]):
-        self.matrices = tuple(matrices)
-
-    def tree_flatten(self) -> tuple[tuple[PreconditionerMatrix, ...], None]:
-        return (self.matrices, None)
-
-    @classmethod
-    def tree_unflatten(cls, aux_data: None, children: tuple[PreconditionerMatrix, ...]) -> "Preconditioner":
-        return cls(children)
-
-    def map(self, fn: Callable[[PreconditionerMatrix], PreconditionerMatrix]) -> "Preconditioner":
-        return Preconditioner(fn(m) for m in self.matrices)
+PreconditionerMatrix: TypeAlias = Array | None
+Preconditioner: TypeAlias = tuple[PreconditionerMatrix, ...]
+PreconditionerMatrixLike: TypeAlias = PreconditionerMatrix | SupportsShapeDtype
+IndexedPreconditionerState: TypeAlias = Mapping[int, PreconditionerMatrixLike]
+LegacyPreconditionerState: TypeAlias = Mapping[str, IndexedPreconditionerState]
+PreconditionerLike: TypeAlias = Preconditioner | IndexedPreconditionerState | LegacyPreconditionerState
 
 
 class SOAPState(NamedTuple):
@@ -138,7 +130,7 @@ def scale_by_soap(
         mu_dtype (chex.ArrayDType, optional): dtype for the first and second moment estimates (exp_avg and exp_avg_sq).
             If None, uses the same dtype as the parameters. Useful for mixed-precision training. Defaults to None.
         qr_dtype (chex.ArrayDType, optional): dtype used for eigen/QR computations and preconditioner storage.
-            Defaults to float32 to avoid float64 upcasts in mixed precision.
+            Defaults to float.
 
     Returns:
         GradientTransformation: The SOAP gradient transformation.
@@ -189,7 +181,7 @@ def scale_by_soap(
         )
 
         new_Q = jtu.tree_map(
-            lambda gg: gg.map(lambda m: get_orthogonal_matrix(m, qr_dtype)),
+            lambda gg: _map_preconditioner(gg, lambda m: get_orthogonal_matrix(m, qr_dtype)),
             new_GG,
             is_leaf=_is_preconditioner,
         )
@@ -298,7 +290,11 @@ def scale_by_soap(
     def update_fn(updates: Updates, state: SOAPState, params: Optional[Updates] = None) -> tuple[Updates, SOAPState]:
         del params
         count_inc = jnp.asarray(optax.safe_int32_increment(state.count))
-        state = state._replace(count=count_inc)
+        state = state._replace(
+            count=count_inc,
+            GG=jtu.tree_map(_preconditioner_matrices, state.GG, is_leaf=_is_preconditioner),
+            Q=jtu.tree_map(_preconditioner_matrices, state.Q, is_leaf=_is_preconditioner),
+        )
 
         updates, new_state = jax.lax.cond(
             count_inc == 1,
@@ -344,15 +340,14 @@ def update_preconditioner(
     beta: float,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
 ) -> Preconditioner:
+    GG = _preconditioner_matrices(GG)
     if grad.ndim == 1:
-        if GG.matrices[0] is None:
+        if GG[0] is None:
             return GG
-        return Preconditioner(
-            [lerp(GG.matrices[0], jnp.matmul(grad[:, None], grad[None, :], precision=precision), 1 - beta)]
-        )
+        return (lerp(GG[0], jnp.matmul(grad[:, None], grad[None, :], precision=precision), 1 - beta),)
 
     new_GG = []
-    for idx, gg in enumerate(GG.matrices):
+    for idx, gg in enumerate(GG):
         if gg is None:
             new_GG.append(None)
             continue
@@ -365,7 +360,7 @@ def update_preconditioner(
         )
         new_GG.append(lerp(gg, outer_product, 1 - beta))
 
-    return Preconditioner(new_GG)
+    return tuple(new_GG)
 
 
 def project(
@@ -373,7 +368,8 @@ def project(
     Q: Preconditioner,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
 ) -> Array:
-    for mat in Q.matrices:
+    Q = _preconditioner_matrices(Q)
+    for mat in Q:
         if mat is not None:
             grad = jnp.tensordot(
                 grad,
@@ -393,7 +389,8 @@ def project_back(
     Q: Preconditioner,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
 ) -> Array:
-    for mat in Q.matrices:
+    Q = _preconditioner_matrices(Q)
+    for mat in Q:
         if mat is not None:
             grad = jnp.tensordot(
                 grad,
@@ -427,8 +424,10 @@ def get_orthogonal_matrix_QR(
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
     qr_dtype: chex.ArrayDType = float,
 ) -> tuple[Preconditioner, Array]:
+    GG = _preconditioner_matrices(GG)
+    Q = _preconditioner_matrices(Q)
     final_Q = []
-    for ind, (m, o) in enumerate(zip(GG.matrices, Q.matrices)):
+    for ind, (m, o) in enumerate(zip(GG, Q)):
         if m is None or o is None:
             final_Q.append(None)
             continue
@@ -452,7 +451,7 @@ def get_orthogonal_matrix_QR(
             Q_new = Q_new.astype(m.dtype)
         final_Q.append(Q_new)
 
-    return Preconditioner(final_Q), exp_avg_sq
+    return tuple(final_Q), exp_avg_sq
 
 
 def lerp(
@@ -471,14 +470,52 @@ def init_conditioner(
 ) -> Preconditioner:
     if p.ndim == 1:
         if not precondition_1d or p.shape[0] > max_precond_dim:
-            return Preconditioner([None])
-        return Preconditioner([jnp.zeros((p.shape[0], p.shape[0]), dtype=dtype)])
+            return (None,)
+        return (jnp.zeros((p.shape[0], p.shape[0]), dtype=dtype),)
 
-    return Preconditioner([jnp.zeros((s, s), dtype=dtype) if s <= max_precond_dim else None for s in p.shape])
+    return tuple(jnp.zeros((s, s), dtype=dtype) if s <= max_precond_dim else None for s in p.shape)
 
 
-def _is_preconditioner(value: object) -> bool:
-    return isinstance(value, Preconditioner)
+def _is_preconditioner(value: PreconditionerLike) -> bool:
+    return _maybe_preconditioner_matrices(value) is not None
+
+
+def _is_preconditioner_matrix(value: PreconditionerMatrixLike) -> bool:
+    return value is None or (hasattr(value, "shape") and hasattr(value, "dtype"))
+
+
+def _map_preconditioner(
+    preconditioner: PreconditionerLike,
+    fn: Callable[[PreconditionerMatrix], PreconditionerMatrix],
+) -> Preconditioner:
+    return tuple(fn(m) for m in _preconditioner_matrices(preconditioner))
+
+
+def _maybe_preconditioner_matrices(value: PreconditionerLike) -> Optional[Preconditioner]:
+    if isinstance(value, tuple) and len(value) > 0 and all(_is_preconditioner_matrix(m) for m in value):
+        return value
+
+    if not isinstance(value, Mapping):
+        return None
+
+    if "matrices" in value:
+        return _maybe_preconditioner_matrices(cast(LegacyPreconditionerState, value)["matrices"])
+
+    keys = tuple(value.keys())
+    if len(keys) > 0 and all(isinstance(k, int) for k in keys):
+        indexed_state = cast(IndexedPreconditionerState, value)
+        matrices = tuple(indexed_state[k] for k in sorted(keys))
+        if all(_is_preconditioner_matrix(m) for m in matrices):
+            return cast(Preconditioner, matrices)
+
+    return None
+
+
+def _preconditioner_matrices(value: PreconditionerLike) -> Preconditioner:
+    matrices = _maybe_preconditioner_matrices(value)
+    if matrices is None:
+        raise TypeError(f"Expected a preconditioner leaf, got {type(value)!r}")
+    return matrices
 
 
 def _resolve_learning_rate(learning_rate: optax.ScalarOrSchedule, count: Array) -> Array:

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -59,7 +59,7 @@ def soap(
     precondition_1d: bool = False,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
     mu_dtype: Optional[chex.ArrayDType] = None,
-    qr_dtype: chex.ArrayDType = jnp.float32,
+    qr_dtype: chex.ArrayDType = float,
 ) -> optax.GradientTransformationExtraArgs:
     """
     Implements SOAP algorithm (https://arxiv.org/abs/2409.11321). Based on the original implementation at https://github.com/nikhilvyas/SOAP.
@@ -117,7 +117,7 @@ def scale_by_soap(
     precondition_1d: bool = False,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
     mu_dtype: Optional[chex.ArrayDType] = None,
-    qr_dtype: chex.ArrayDType = jnp.float32,
+    qr_dtype: chex.ArrayDType = float,
 ) -> GradientTransformation:
     """
     Implements SOAP algorithm (https://arxiv.org/abs/2409.11321). Based on the original implementation at https://github.com/nikhilvyas/SOAP.
@@ -170,7 +170,7 @@ def scale_by_soap(
             params,
         )
         return SOAPState(
-            count=jnp.zeros([], jnp.int32),
+            count=jnp.zeros([], int),
             exp_avg=exp_avg,
             exp_avg_sq=exp_avg_sq,
             GG=GG,
@@ -320,7 +320,7 @@ def add_decayed_weights_post(
 
     def init_fn(params: Updates) -> PostDecayState:
         del params
-        return PostDecayState(count=jnp.zeros([], jnp.int32))
+        return PostDecayState(count=jnp.zeros([], int))
 
     def update_fn(
         updates: Updates, state: PostDecayState, params: Optional[Updates] = None
@@ -425,7 +425,7 @@ def get_orthogonal_matrix_QR(
     Q: Preconditioner,
     exp_avg_sq: Array,
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
-    qr_dtype: chex.ArrayDType = jnp.float32,
+    qr_dtype: chex.ArrayDType = float,
 ) -> tuple[Preconditioner, Array]:
     final_Q = []
     for ind, (m, o) in enumerate(zip(GG.matrices, Q.matrices)):

--- a/tests/test_equinox.py
+++ b/tests/test_equinox.py
@@ -1,0 +1,76 @@
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+
+from soap_jax import soap
+
+
+class TinyMLP(eqx.Module):
+    layers: list[eqx.nn.Linear]
+
+    def __init__(self, key: jax.Array, in_dim: int, hidden_dim: int, out_dim: int):
+        key1, key2 = jax.random.split(key)
+        self.layers = [  # ty:ignore[invalid-assignment]
+            eqx.nn.Linear(in_dim, hidden_dim, key=key1),
+            eqx.nn.Linear(hidden_dim, out_dim, key=key2),
+        ]
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        x = jnp.tanh(self.layers[0](x))
+        return self.layers[1](x)
+
+
+def make_data(
+    key: jax.Array, num_samples: int = 64, input_dim: int = 8, output_dim: int = 3
+) -> tuple[jax.Array, jax.Array]:
+    key_x, key_w, key_b = jax.random.split(key, 3)
+    x = jax.random.normal(key_x, (num_samples, input_dim))
+    true_w = jax.random.normal(key_w, (input_dim, output_dim))
+    true_b = jax.random.normal(key_b, (output_dim,))
+    y = x @ true_w + true_b
+    return x, y
+
+
+def compute_loss(model: TinyMLP, x: jax.Array, y: jax.Array) -> jax.Array:
+    predictions = jax.vmap(model)(x)
+    return jnp.mean((predictions - y) ** 2)
+
+
+@eqx.filter_jit
+def train_step(
+    model: TinyMLP,
+    opt_state: optax.OptState,
+    x: jax.Array,
+    y: jax.Array,
+    optimizer: optax.GradientTransformation,
+) -> tuple[TinyMLP, optax.OptState, jax.Array]:
+    loss, grads = eqx.filter_value_and_grad(compute_loss)(model, x, y)
+    updates, opt_state = optimizer.update(grads, opt_state, model)  # ty:ignore[invalid-argument-type]
+    model = eqx.apply_updates(model, updates)
+    return model, opt_state, loss
+
+
+def test_soap_trains_a_small_equinox_mlp() -> None:
+    key = jax.random.PRNGKey(0)
+    data_key, model_key = jax.random.split(key)
+    x, y = make_data(data_key)
+
+    model: TinyMLP
+    model = TinyMLP(model_key, in_dim=x.shape[-1], hidden_dim=16, out_dim=y.shape[-1])  # ty:ignore[invalid-assignment]
+    optimizer = soap(
+        learning_rate=3e-2,
+        precondition_frequency=2,
+        precondition_1d=False,
+        weight_decay=0.0,
+    )
+    opt_state = optimizer.init(eqx.filter(model, eqx.is_array))
+
+    initial_loss = float(compute_loss(model, x, y))
+
+    for _ in range(40):
+        model, opt_state, _ = train_step(model, opt_state, x, y, optimizer)
+
+    final_loss = float(compute_loss(model, x, y))
+
+    assert final_loss < initial_loss * 0.5

--- a/tests/test_flax_nnx.py
+++ b/tests/test_flax_nnx.py
@@ -15,6 +15,14 @@ class TinyMLP(nnx.Module):
         return self.linear2(x)
 
 
+class ScalarGainModel(nnx.Module):
+    def __init__(self, initial_gain: float = 0.5):
+        self.gain = nnx.Param(jnp.asarray(initial_gain, dtype=jnp.float32))
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        return self.gain[...] * x
+
+
 def make_data(
     key: jax.Array,
     num_samples: int = 64,
@@ -29,13 +37,13 @@ def make_data(
     return x, y
 
 
-def compute_loss(model: TinyMLP, x: jax.Array, y: jax.Array) -> jax.Array:
+def compute_loss(model: nnx.Module, x: jax.Array, y: jax.Array) -> jax.Array:
     predictions = model(x)
     return jnp.mean((predictions - y) ** 2)
 
 
 @nnx.jit
-def train_step(model: TinyMLP, optimizer: nnx.Optimizer, x: jax.Array, y: jax.Array) -> jax.Array:
+def train_step(model: nnx.Module, optimizer: nnx.Optimizer, x: jax.Array, y: jax.Array) -> jax.Array:
     loss, grads = nnx.value_and_grad(compute_loss, argnums=nnx.DiffState(0, nnx.Param))(model, x, y)
     optimizer.update(model, grads)
     return loss
@@ -67,3 +75,29 @@ def test_soap_trains_a_small_flax_nnx_mlp() -> None:
 
     assert final_loss < initial_loss * 0.5
     assert int(optimizer.step.value) == 40
+
+
+def test_soap_handles_scalar_flax_nnx_params() -> None:
+    x = jnp.linspace(-1.0, 1.0, 64, dtype=jnp.float32)[:, None]
+    y = 2.0 * x
+
+    model = ScalarGainModel()
+    optimizer = nnx.Optimizer(
+        model,
+        soap(
+            learning_rate=1e-1,
+            precondition_frequency=2,
+            precondition_1d=False,
+            weight_decay=0.0,
+        ),
+        wrt=nnx.Param,
+    )
+
+    initial_loss = float(compute_loss(model, x, y))
+
+    for _ in range(20):
+        train_step(model, optimizer, x, y)
+
+    final_loss = float(compute_loss(model, x, y))
+
+    assert final_loss < initial_loss * 0.1

--- a/tests/test_flax_nnx.py
+++ b/tests/test_flax_nnx.py
@@ -1,0 +1,69 @@
+import jax
+import jax.numpy as jnp
+from flax import nnx
+
+from soap_jax import soap
+
+
+class TinyMLP(nnx.Module):
+    def __init__(self, in_dim: int, hidden_dim: int, out_dim: int, *, rngs: nnx.Rngs):
+        self.linear1 = nnx.Linear(in_dim, hidden_dim, rngs=rngs)
+        self.linear2 = nnx.Linear(hidden_dim, out_dim, rngs=rngs)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        x = jnp.tanh(self.linear1(x))
+        return self.linear2(x)
+
+
+def make_data(
+    key: jax.Array,
+    num_samples: int = 64,
+    input_dim: int = 8,
+    output_dim: int = 3,
+) -> tuple[jax.Array, jax.Array]:
+    key_x, key_w, key_b = jax.random.split(key, 3)
+    x = jax.random.normal(key_x, (num_samples, input_dim))
+    true_w = jax.random.normal(key_w, (input_dim, output_dim))
+    true_b = jax.random.normal(key_b, (output_dim,))
+    y = x @ true_w + true_b
+    return x, y
+
+
+def compute_loss(model: TinyMLP, x: jax.Array, y: jax.Array) -> jax.Array:
+    predictions = model(x)
+    return jnp.mean((predictions - y) ** 2)
+
+
+@nnx.jit
+def train_step(model: TinyMLP, optimizer: nnx.Optimizer, x: jax.Array, y: jax.Array) -> jax.Array:
+    loss, grads = nnx.value_and_grad(compute_loss, argnums=nnx.DiffState(0, nnx.Param))(model, x, y)
+    optimizer.update(model, grads)
+    return loss
+
+
+def test_soap_trains_a_small_flax_nnx_mlp() -> None:
+    key = jax.random.PRNGKey(0)
+    data_key, model_key = jax.random.split(key)
+    x, y = make_data(data_key)
+
+    model = TinyMLP(x.shape[-1], 16, y.shape[-1], rngs=nnx.Rngs(model_key))
+    optimizer = nnx.Optimizer(
+        model,
+        soap(
+            learning_rate=1e-2,
+            precondition_frequency=2,
+            precondition_1d=False,
+            weight_decay=0.0,
+        ),
+        wrt=nnx.Param,
+    )
+
+    initial_loss = float(compute_loss(model, x, y))
+
+    for _ in range(40):
+        train_step(model, optimizer, x, y)
+
+    final_loss = float(compute_loss(model, x, y))
+
+    assert final_loss < initial_loss * 0.5
+    assert int(optimizer.step.value) == 40

--- a/tests/test_flax_nnx.py
+++ b/tests/test_flax_nnx.py
@@ -50,7 +50,7 @@ def test_soap_trains_a_small_flax_nnx_mlp() -> None:
     optimizer = nnx.Optimizer(
         model,
         soap(
-            learning_rate=1e-2,
+            learning_rate=3e-2,
             precondition_frequency=2,
             precondition_1d=False,
             weight_decay=0.0,


### PR DESCRIPTION
## Summary
- Replace the SOAP preconditioner wrapper with plain pytree state so Optax state round-trips cleanly through `flax.nnx.Optimizer`
- Normalize preconditioner leaves at the Optax/NNX boundary to handle `nnx.State`-wrapped mappings and keep branch structure consistent
- Tighten helper type hints around the preconditioner normalization path
- Update test dependencies and keep the Equinox and NNX training tests aligned with the new state shape
- Add integration tests for equinox and NNX

The behaviour is as far as I know unchanged, that is, the output from running the example script is identical.