### PR TITLE
Fix Preconditioner state corruption when nnx.Variable-wrapped params passed to init_fn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 description = "SOAP Optimizer implemented in JAX"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
-dependencies = ["jax", "jaxtyping", "optax"]
+dependencies = ["jax", "jaxtyping", "optax", "chex"]
 
 [build-system]
 requires = ["uv_build>=0.8.5"]

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -9,8 +9,12 @@ import optax
 import optax.tree_utils as otu
 from chex import Numeric
 from jaxtyping import Array
-from flax.nnx.variablelib import Variable
 from optax import GradientTransformation, Updates
+
+try:
+    from flax.nnx.variablelib import Variable as NnxVariable
+except ImportError:
+    NnxVariable = None
 
 PreconditionerMatrix = Union[Array, None]
 
@@ -160,11 +164,12 @@ def scale_by_soap(
     shampoo_beta = shampoo_beta if shampoo_beta >= 0 else b2
 
     def init_fn(params: Updates) -> SOAPState:
-        params = jtu.tree_map(
-            lambda p: p.get_value() if isinstance(p, Variable) else p,
-            params,
-            is_leaf=lambda x: isinstance(x, Variable),
-        )
+        if NnxVariable is not None:
+            params = jtu.tree_map(
+                lambda p: p.get_value() if isinstance(p, NnxVariable) else p,
+                params,
+                is_leaf=lambda x: isinstance(x, NnxVariable),
+            )
         exp_avg = otu.tree_zeros_like(params, dtype=mu_dtype)
         exp_avg_sq = otu.tree_zeros_like(params, dtype=mu_dtype)
         GG = jtu.tree_map(

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -166,7 +166,7 @@ def scale_by_soap(
     def init_fn(params: Updates) -> SOAPState:
         if NnxVariable is not None:
             params = jtu.tree_map(
-                lambda p: p.get_value() if isinstance(p, NnxVariable) else p,
+                lambda p: _unwrap(p) if isinstance(p, NnxVariable) else p,
                 params,
                 is_leaf=lambda x: isinstance(x, NnxVariable),
             )
@@ -490,6 +490,14 @@ def init_conditioner(
 
 def _is_preconditioner(value: object) -> bool:
     return isinstance(value, Preconditioner)
+
+
+def _unwrap(p: object) -> object:
+    """Unwrap an nnx.Variable to its underlying array.
+
+    flax >= 0.12 Variable has get_value(); flax 0.11 and earlier only has .value.
+    """
+    return p.get_value() if hasattr(p, "get_value") else p.value
 
 
 def _resolve_learning_rate(learning_rate: optax.ScalarOrSchedule, count: Array) -> Array:

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -12,7 +12,7 @@ from jaxtyping import Array
 from optax import GradientTransformation, Updates
 
 try:
-    from flax.nnx.variablelib import Variable as NnxVariable
+    from flax.nnx import Variable as NnxVariable
 except ImportError:
     NnxVariable = None
 

--- a/src/soap_jax/soap.py
+++ b/src/soap_jax/soap.py
@@ -9,6 +9,7 @@ import optax
 import optax.tree_utils as otu
 from chex import Numeric
 from jaxtyping import Array
+from flax.nnx.variablelib import Variable
 from optax import GradientTransformation, Updates
 
 PreconditionerMatrix = Union[Array, None]
@@ -159,6 +160,11 @@ def scale_by_soap(
     shampoo_beta = shampoo_beta if shampoo_beta >= 0 else b2
 
     def init_fn(params: Updates) -> SOAPState:
+        params = jtu.tree_map(
+            lambda p: p.get_value() if isinstance(p, Variable) else p,
+            params,
+            is_leaf=lambda x: isinstance(x, Variable),
+        )
         exp_avg = otu.tree_zeros_like(params, dtype=mu_dtype)
         exp_avg_sq = otu.tree_zeros_like(params, dtype=mu_dtype)
         GG = jtu.tree_map(


### PR DESCRIPTION
## Motivation
`flax.nnx` has become the recommended API for new Flax projects, and more
users are likely to reach for `nnx.Optimizer` going forward. This PR makes
`soap_jax.soap` work correctly when used that way, without changing any
behavior for existing Linen/`TrainState` users.

## Problem
When `scale_by_soap`'s `init_fn` receives params from `nnx.Optimizer` (as
`flax.nnx.Variable`-wrapped leaves rather than bare arrays), the resulting
`Preconditioner` state gets corrupted after the first optimizer step.

## Root cause
`nnx.Optimizer` passes params as `nnx.Param` (a `Variable` subclass). Without
unwrapping, `jtu.tree_map` traverses into `Param(array)` and reconstructs
`Param(Preconditioner)`. On the next step, `nnx.state` flattens `Preconditioner`
into `State({0: arr, 1: arr})`, destroying the original type.

## Fix
Strip `Variable` wrappers at the top of `init_fn` before building `GG`/`Q`.
Guarded by an `isinstance` check, so behavior with plain pytrees (e.g. Linen's
`TrainState`) is unchanged — `isinstance(p, Variable)` is `False` for bare
arrays, so params pass through untouched.

## Verification
Compared `soap` run via Linen `TrainState` vs. the same optimizer run via
`nnx.Optimizer`, same initial weights and inputs, 10 steps each. Predictions
match to `atol=1e-10`. 
```python
import jax
jax.config.update("jax_enable_x64", True)

import jax.numpy as jnp
from flax import linen as nn
from flax import nnx
from flax.training import train_state
from soap_jax.soap import soap

DTYPE = jnp.float64
KEY = jax.random.PRNGKey(0)
x = jnp.linspace(0, 2 * jnp.pi, 256, dtype=DTYPE)[:, None]
y = jnp.sin(x)

OPT_KWARGS = dict(
    learning_rate=3e-4, b1=0.95, b2=0.95,
    precondition_frequency=5, weight_decay=0.0, qr_dtype=DTYPE,
)


class MLPLinen(nn.Module):
    @nn.compact
    def __call__(self, x):
        x = nn.relu(nn.Dense(32, dtype=DTYPE, param_dtype=DTYPE)(x))
        x = nn.relu(nn.Dense(32, dtype=DTYPE, param_dtype=DTYPE)(x))
        return nn.Dense(1, dtype=DTYPE, param_dtype=DTYPE)(x)


class MLPNnx(nnx.Module):
    def __init__(self, rngs: nnx.Rngs, dtype=DTYPE):
        self.layer1 = nnx.Linear(1, 32, rngs=rngs, dtype=dtype)
        self.layer2 = nnx.Linear(32, 32, rngs=rngs, dtype=dtype)
        self.layer3 = nnx.Linear(32, 1, rngs=rngs, dtype=dtype)

    def __call__(self, x):
        x = nnx.relu(self.layer1(x))
        x = nnx.relu(self.layer2(x))
        return self.layer3(x)


# --- Linen reference, via train_state.TrainState ---
model_l = MLPLinen()
params = model_l.init(KEY, x)
state_l = train_state.TrainState.create(
    apply_fn=model_l.apply, params=params, tx=soap(**OPT_KWARGS),
)

# --- NNX model with identical initial weights, via nnx.Optimizer ---
model_n = MLPNnx(rngs=nnx.Rngs(0), dtype=DTYPE)
pp = params["params"]
model_n.layer1.kernel.value = pp["Dense_0"]["kernel"]
model_n.layer1.bias.value = pp["Dense_0"]["bias"]
model_n.layer2.kernel.value = pp["Dense_1"]["kernel"]
model_n.layer2.bias.value = pp["Dense_1"]["bias"]
model_n.layer3.kernel.value = pp["Dense_2"]["kernel"]
model_n.layer3.bias.value = pp["Dense_2"]["bias"]

optimizer_n = nnx.Optimizer(model_n, soap(**OPT_KWARGS), wrt=nnx.Param)

assert jnp.allclose(model_l.apply(params, x), model_n(x), atol=1e-10), \
    "initial params do not match between Linen and NNX"


# --- run both for 10 steps ---
def linen_loss_fn(p):
    return jnp.mean((model_l.apply(p, x) - y) ** 2)


def nnx_loss_fn(m):
    return jnp.mean((m(x) - y) ** 2)


for step in range(10):
    loss_l, grads_l = jax.value_and_grad(linen_loss_fn)(state_l.params)
    state_l = state_l.apply_gradients(grads=grads_l)

    loss_n, grads_n = nnx.value_and_grad(nnx_loss_fn)(model_n)
    optimizer_n.update(model_n, grads_n)  # <- raised AttributeError on step 2 before the fix

    print(f"step {step:>2}  linen_loss={float(loss_l):.6f}  nnx_loss={float(loss_n):.6f}")


# --- final numerical check ---
y_linen = model_l.apply(state_l.params, x)
y_nnx = model_n(x)
max_diff = float(jnp.max(jnp.abs(y_linen - y_nnx)))
print(f"\nmax diff after 10 steps: {max_diff:.2e}")

assert jnp.allclose(y_linen, y_nnx, atol=1e-10), f"FAIL  max_diff={max_diff:.2e}"
print("PASS  soap now matches across Linen TrainState and nnx.Optimizer  atol=1e-10")
```